### PR TITLE
Stop damage during death animation

### DIFF
--- a/Assets/Prefabs/Enemies/Bosses/Minions/Bee.prefab
+++ b/Assets/Prefabs/Enemies/Bosses/Minions/Bee.prefab
@@ -51,7 +51,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _spriteAnimator: {fileID: -1115205014107361229}
   _bossAttackAnimator: {fileID: 0}
-  isAngry: 0
+  IsAngry: 0
 --- !u!114 &-3877636426582682918
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -200,6 +200,6 @@ CircleCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
+  m_Offset: {x: -0.03, y: 0.01}
   serializedVersion: 2
-  m_Radius: 0.29
+  m_Radius: 0.15

--- a/Assets/Scripts/Enemy/BaseBossController.cs
+++ b/Assets/Scripts/Enemy/BaseBossController.cs
@@ -9,6 +9,7 @@ public class BaseBossController : MonoBehaviour
     protected readonly float _pushbacktime = .25f, _pauseTime = .5f;
     protected Transform _player;
     protected Rigidbody2D _rb;
+    protected Collider2D _collider;
     protected BossHealth _health;
     protected bool _enablePause = false;
     protected bool _pauseMovement = false;
@@ -21,6 +22,7 @@ public class BaseBossController : MonoBehaviour
     {
         _player = GameObject.FindWithTag("Player").transform;
         _rb = GetComponent<Rigidbody2D>();
+        _collider = GetComponent<Collider2D>();
         _health = GetComponent<BossHealth>();
         _health.TriggerDeath.AddListener(() => EnemyDeath());
     }

--- a/Assets/Scripts/Enemy/FollowBossController.cs
+++ b/Assets/Scripts/Enemy/FollowBossController.cs
@@ -14,6 +14,9 @@ public class FollowBossController: BaseBossController
     protected override void Move()
     {
         base.Move();
+        if (_pauseMovement)
+            return;
+
         transform.position = Vector3.MoveTowards(_rb.position, _player.position, CurrentSpeed * Time.fixedDeltaTime);
         _rb.velocity = Vector2.zero;
     }

--- a/Assets/Scripts/Enemy/Minions/BeeController.cs
+++ b/Assets/Scripts/Enemy/Minions/BeeController.cs
@@ -33,6 +33,8 @@ public class BeeController : FollowBossController
 
     protected override void EnemyDeath()
     {
+        _pauseMovement = true;
+        _collider.enabled = false;
         _spriteAnimator.SetTrigger("death");
     }
 }

--- a/Assets/Scripts/Enemy/Minions/BubbleController.cs
+++ b/Assets/Scripts/Enemy/Minions/BubbleController.cs
@@ -47,6 +47,8 @@ public class BubbleController : FollowBossController
 
     protected override void EnemyDeath()
     {
+        _pauseMovement = true;
+        _collider.enabled = false;
         _spriteAnimator.SetTrigger("death");
     }
 }


### PR DESCRIPTION
- minions were continuing to damage the player during their death animation. Removing that logic here.